### PR TITLE
fixed NullReferenceException when reg key is not found

### DIFF
--- a/OneDriveLib/UacHelper.cs
+++ b/OneDriveLib/UacHelper.cs
@@ -71,7 +71,7 @@ namespace OneDriveLib
             get
             {
                 RegistryKey uacKey = Registry.LocalMachine.OpenSubKey(uacRegistryKey, false);
-                bool result = uacKey.GetValue(uacRegistryValue).Equals(1);
+                bool result = (uacKey?.GetValue(uacRegistryValue) ?? 1).Equals(1);
                 return result;
             }
         }


### PR DESCRIPTION
I came across some machines that did not have the EnableLUA for some reason. In that case the code would throw a NullReferenceException.

According to the docs [here](https://docs.microsoft.com/en-us/windows-hardware/customize/desktop/unattend/microsoft-windows-lua-settings-enablelua) the default value for EnableLUA is True.

The proposed change makes the IsUacEnabled property return True if the key or subkey are not found instead of throwing the exception.