### PR TITLE
Inaccessible Registry Keys Throw Unhandled SecurityException

### DIFF
--- a/OneDriveLib/IShellIconOverlayIdentifier.cs
+++ b/OneDriveLib/IShellIconOverlayIdentifier.cs
@@ -131,6 +131,8 @@ namespace Native
         {
             State = new OneDriveState();
             uint hr = 0;
+            if (SyncRootId is null)
+                return 1;
             if (Marshal.SizeOf(IntPtr.Zero) == 8)
                hr = GetStatusByTypeApi(SyncRootId, ref State);
             else

--- a/OneDriveLib/OdSyncStatusWS.cs
+++ b/OneDriveLib/OdSyncStatusWS.cs
@@ -66,6 +66,7 @@ namespace OdSyncService
         {
             //const string hklm = "HKEY_LOCAL_MACHINE";
             const string subkeyString = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\SyncRootManager\"; // SkyDrive\UserSyncRoots\";
+            var detail = new StatusDetail();
 
             using (var key = Registry.LocalMachine.OpenSubKey(subkeyString))
             {
@@ -81,54 +82,59 @@ namespace OdSyncService
                     }
                     foreach (var subkey in key.GetSubKeyNames())
                     {
-                        var displayKey = key.OpenSubKey(subkey);
-                        var displayName = displayKey?.GetValue("DisplayNameResource") as string;
-                        using (var userKey = key.OpenSubKey(String.Format("{0}{1}", subkey, @"\UserSyncRoots")))
+                        try
                         {
-                            if (userKey != null && userKey.Name.Contains(UserSID))
+                            detail = new StatusDetail();
+                            var displayKey = key.OpenSubKey(subkey);
+                            var displayName = displayKey?.GetValue("DisplayNameResource") as string;
+                            using (var userKey = key.OpenSubKey(String.Format("{0}{1}", subkey, @"\UserSyncRoots")))
                             {
-                                
-                                
-                                foreach (var valueName in userKey.GetValueNames())
+                                if (userKey != null && userKey.Name.Contains(UserSID))
                                 {
-                                    var detail = new StatusDetail();
-                                    try
+                                    
+                                    
+                                    foreach (var valueName in userKey.GetValueNames())
                                     {
-                                        var id = new SecurityIdentifier(valueName);
-                                        string userName = id.Translate(typeof(NTAccount)).Value;
-                                        detail.UserName = userName;
-                                        detail.UserSID = valueName;
-                                        detail.DisplayName = displayName;
-                                        detail.SyncRootId = subkey;
-                                        
-                                        string[] parts = userKey.Name.Split('!');
-
-                                        if (parts.Length > 1)
+                                        detail = new StatusDetail();
+                                        try
                                         {
-                                            detail.ServiceType = parts[Math.Min(2, parts.Length - 1)].Split('|')[0];
-                                        } else
-                                        {
-                                            detail.ServiceType = "INVALID";
+                                            var id = new SecurityIdentifier(valueName);
+                                            string userName = id.Translate(typeof(NTAccount)).Value;
+                                            detail.UserName = userName;
+                                            detail.UserSID = valueName;
+                                            detail.DisplayName = displayName;
+                                            detail.SyncRootId = subkey;
+                                            
+                                            string[] parts = userKey.Name.Split('!');
+    
+                                            if (parts.Length > 1)
+                                            {
+                                                detail.ServiceType = parts[Math.Min(2, parts.Length - 1)].Split('|')[0];
+                                            } else
+                                            {
+                                                detail.ServiceType = "INVALID";
+                                            }
                                         }
+                                        catch (Exception ex)
+                                        {
+                                            detail.UserName = String.Format("{0}: {1}", ex.GetType().ToString(),
+                                                ex.Message);
+                                            OneDriveLib.WriteLog.WriteErrorEvent("OneDrive " + detail.UserName);
+                                        }
+                                        detail.LocalPath = userKey.GetValue(valueName) as string;
+                                        detail.StatusString = GetStatus(detail.LocalPath).ToString();
                                     }
-                                    catch (Exception ex)
-                                    {
-                                        detail.UserName = String.Format("{0}: {1}", ex.GetType().ToString(),
-                                            ex.Message);
-                                        OneDriveLib.WriteLog.WriteErrorEvent("OneDrive " + detail.UserName);
-                                    }
-                                    detail.LocalPath = userKey.GetValue(valueName) as string;
-                                    detail.StatusString = GetStatus(detail.LocalPath).ToString();
-                                    yield return detail;
                                 }
                             }
                         }
+                        catch (SecurityException)
+                        {
+                            detail = new StatusDetail() { Status = ServiceStatus.OnDemandOrUnknown };
+                        }
+                        yield return detail;
                     }
                 }
             }
-
-
-
         }
 
         public IEnumerable<StatusDetail> GetStatusInternalGroove()
@@ -201,6 +207,8 @@ namespace OdSyncService
 
             foreach (var status in GetStatusInternal())
             {
+                if (status.SyncRootId is null)
+                    continue;
                 OneDriveState state = new OneDriveState();
                 var hr = API.GetStateBySyncRootId(status.SyncRootId, out state);
                 if(hr == 0)


### PR DESCRIPTION
If other users on the computer have OneDrive enabled, and the user context running does not have access to every key in HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\SyncRootManager, then OdSyncStatusWS.GetStatusInternal() will throw an unhandled SecurityException.

I have moved the declaration of detail higher in the method, wrapped the dangerous code in a try/catch (with a couple reinits of detail to account for it not being redeclared in every loop), and set detail to a default StatusDetail() if exception is caught. The yield return is moved out of try/catch.

This leads, however, to API.GetStateBySyncRootId potentially being passed a null SyncRootId and throwing an invalid memory access error. I have prevented this in two ways: GetStatusBySyncRootId now has a null check that immediately returns 1. Addtionally, OdSyncStatusWS.GetStatus now checks for a null SyncRootId before calling GetStateBySyncRootId.
